### PR TITLE
fixed bugs

### DIFF
--- a/bstlab.cpp
+++ b/bstlab.cpp
@@ -38,9 +38,10 @@ BstNode* findInorderSuccessor(BstNode* rootref){
 	if(temp == NULL){
 		return temp;
 	}
-	if(temp->left == NULL){
+	if(temp->right == NULL){
 		return temp;
 	}
+	temp=temp->right;
 	while(temp->left!=NULL){
 		temp = temp -> left;
 	}
@@ -52,9 +53,10 @@ BstNode* findInorderPredecessor(BstNode* rootref){
 	if(temp == NULL){
 		return temp;
 	}
-	if(temp->right == NULL){
-		return temp;
+	if(temp->left == NULL){
+		return temp->par;
 	}
+	temp=temp->left;
 	while(temp->right!=NULL){
 		temp = temp -> right;
 	}


### PR DESCRIPTION
Bugs in functions
1) findInorderSuccessor(BstNode* root ref)  : The next node will be the extreme left child of the right child. 

2) findInorderPredecessor(BstNode* rootref) : the previous node will be the extreme right child of the left child. If there is no left child then the previous node can either be NULL or the parent node depending on whether rootref is the right or left child of its parent.